### PR TITLE
fix: fix getSessionKey for inline mode

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -29,11 +29,17 @@ class LocalSession {
       property: 'session',
       state: { },
       getSessionKey: (ctx) => {
-        if (ctx.updateType === 'callback_query') {
-          ctx = ctx.update.callback_query.message
+        if (!ctx.from) return // should never happen
+
+        let chatInstance = ctx.from.id
+        if (ctx.chat) {
+          chatInstance = ctx.chat.id
+        } else if (ctx.updateType === 'callback_query') {
+          chatInstance = ctx.callbackQuery.chat_instance
+        } else { // if (ctx.updateType === 'inline_query') {
+          chatInstance = ctx.from.id
         }
-        if (!ctx.from || !ctx.chat) return
-        return ctx.chat.id + ':' + ctx.from.id
+        return chatInstance + ':' + ctx.from.id
       }
     }, options)
     if (this.options.storage === LocalSession.storageMemory) {

--- a/tests/sessionKeyUpdateTypes.js
+++ b/tests/sessionKeyUpdateTypes.js
@@ -1,0 +1,59 @@
+/* eslint object-curly-spacing: ["error", "always"] */
+const
+  Telegraf = require('telegraf'),
+  LocalSession = require('../lib/session'),
+  should = require('should'),
+  debug = require('debug')('telegraf:session-local:test'),
+  options = { storage: LocalSession.storageMemory }
+
+describe('Telegraf Session local : Session Key Update Types', () => {
+  let bot = {}
+  let localSession = new LocalSession(options)
+
+  it('Should handle message', (done) => {
+    bot = new Telegraf()
+    bot.on('text', (ctx) => {
+      const sessionKey = localSession.getSessionKey(ctx)
+      debug('Session key', sessionKey)
+      sessionKey.should.be.equal('2:1')
+      done()
+    })
+    bot.handleUpdate({ message: { chat: { id: 2 }, from: { id: 1 }, text: 'hey' } })
+  })
+
+  it('Should handle inline_query', (done) => {
+    bot = new Telegraf()
+    bot.on('inline_query', (ctx) => {
+      const sessionKey = localSession.getSessionKey(ctx)
+      debug('Session key', sessionKey)
+      should.exist(sessionKey)
+      sessionKey.should.be.equal('1:1')
+      done()
+    })
+    bot.handleUpdate({ inline_query: { from: { id: 1 }, query: '' } })
+  })
+
+  it('Should handle callback_query from chat', (done) => {
+    bot = new Telegraf()
+    bot.action('c:b', (ctx) => {
+      const sessionKey = localSession.getSessionKey(ctx)
+      debug('Session key', sessionKey)
+      should.exist(sessionKey)
+      sessionKey.should.be.equal('2:1')
+      done()
+    })
+    bot.handleUpdate({ callback_query: { from: { id: 1 }, message: { from: { id: 1 }, chat: { id: 2 }, text: 'hey' }, chat_instance: '-123', data: 'c:b' } })
+  })
+
+  it('Should handle callback_query from inline_query message', (done) => {
+    bot = new Telegraf()
+    bot.action('c:b', (ctx) => {
+      const sessionKey = localSession.getSessionKey(ctx)
+      debug('Session key', sessionKey)
+      should.exist(sessionKey)
+      sessionKey.should.be.equal('-123:1')
+      done()
+    })
+    bot.handleUpdate({ callback_query: { from: { id: 1 }, inline_message_id: 'BAA', chat_instance: '-123', data: 'c:b' } })
+  })
+})

--- a/tests/sessionKeyUpdateTypes.js
+++ b/tests/sessionKeyUpdateTypes.js
@@ -42,7 +42,7 @@ describe('Telegraf Session local : Session Key Update Types', () => {
       sessionKey.should.be.equal('2:1')
       done()
     })
-    bot.handleUpdate({ callback_query: { from: { id: 1 }, message: { from: { id: 1 }, chat: { id: 2 }, text: 'hey' }, chat_instance: '-123', data: 'c:b' } })
+    bot.handleUpdate({ callback_query: { from: { id: 1 }, message: { from: { id: 3 }, chat: { id: 2 }, text: 'hey' }, chat_instance: '-123', data: 'c:b' } })
   })
 
   it('Should handle callback_query from inline_query message', (done) => {


### PR DESCRIPTION
- `inline_query` does not have a connection to a chat and so no chat property.
- `callback_query` from a chat does not need the `ctx.update.callback_query.message.chat` shortcut. The `ctx.chat` property is already filled by the Context class. ([here](https://github.com/telegraf/telegraf/blob/50a13f7c819ee80e7ce3da2488e020b0a84b1dd6/lib/core/context.js#L102-L108))
- `callback_query` from an inline bot message does not contain the `message` property. Instead it has the `inline_message_id`. Only `chat_instance` can be used for this.

See the type descriptions from the official api documentation: [CallbackQuery](https://core.telegram.org/bots/api#callbackquery) and [InlineQuery](https://core.telegram.org/bots/api#inlinequery)

This is not tested with [Payments](https://core.telegram.org/bots/api#payments)