### PR TITLE
refactor: import per line and all on top

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -1,9 +1,12 @@
-const
-  debug = require('debug')('telegraf:session-local'),
-  lowdb = require('lowdb'),
-  storageFileSync = require('lowdb/adapters/FileSync'),
-  storageFileAsync = require('lowdb/adapters/FileAsync'),
-  storageMemory = require('lowdb/adapters/Memory')
+const Debug = require('debug')
+const lowdb = require('lowdb')
+const storageFileAsync = require('lowdb/adapters/FileAsync')
+const storageFileSync = require('lowdb/adapters/FileSync')
+const storageMemory = require('lowdb/adapters/Memory')
+
+const lodashId = require('./lodash-id.js')
+
+const debug = Debug('telegraf:session-local')
 
 /**
  * Represents a wrapper around locally stored session, it's {@link LocalSession#middleware|middleware} & lowdb
@@ -271,7 +274,7 @@ class LocalSession {
 
 function _initDB () {
   // Use ID based resources, so we can query records by ID (ex.: getById(), removeById(), ...)
-  this.DB._.mixin(require('./lodash-id.js'))
+  this.DB._.mixin(lodashId)
   // If database is empty, fill it with empty Array of sessions and optionally with initial state
   this.DB.defaults(Object.assign({ sessions: [] }, this.options.state)).write()
   debug('Initiating finished')


### PR DESCRIPTION
do imports one per line and without inline function calls. Also get inline require up to the top.

Its simpler to see what the file uses as dependencies