### PR TITLE
fix(typings): adapt to typing changes of telegraf 3.38

### DIFF
--- a/lib/session.d.ts
+++ b/lib/session.d.ts
@@ -1,6 +1,7 @@
 declare module 'telegraf-session-local' {
-  import { AdapterSync, AdapterAsync, BaseAdapter, lowdb } from 'lowdb'
-  import { ContextMessageUpdate, Middleware } from 'telegraf'
+  import { AdapterSync, AdapterAsync, BaseAdapter } from 'lowdb'
+  import { Context } from 'telegraf'
+  import { MiddlewareFn } from 'telegraf/typings/composer'
 
   export interface LocalSessionOptions<TSession> {
     storage?: AdapterSync | AdapterAsync
@@ -11,7 +12,7 @@ declare module 'telegraf-session-local' {
         serialize?: (value: TSession) => string
         deserialize?: (value: string) => TSession
     }
-    getSessionKey?: (ctx: ContextMessageUpdate) => string
+    getSessionKey?: (ctx: Context) => string
   }
 
   class LocalSession<TSession> {
@@ -19,10 +20,10 @@ declare module 'telegraf-session-local' {
 
     constructor(options?: LocalSessionOptions<TSession>)
 
-    getSessionKey(ctx: ContextMessageUpdate): string
+    getSessionKey(ctx: Context): string
     getSession(key: string): TSession
     saveSession(key: string, data: TSession): Promise<TSession>
-    middleware(property?: string): Middleware<ContextMessageUpdate>
+    middleware(property?: string): MiddlewareFn<Context>
     static get storageFileSync(): AdapterSync
     static get storageFileAsync(): AdapterAsync
     static get storageMemory(): AdapterSync

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Tema Smirnov <npm.tema@smirnov.one>",
   "license": "MIT",
   "contributors": [
-    "Edgar Toll <edjopato@gmail.com> (https://edjopato.de/)"
+    "EdJoPaTo <telegraf-session-local-npm-package@edjopato.de> (https://edjopato.de/)"
   ],
   "bugs": {
     "url": "https://github.com/RealSpeaker/telegraf-session-local/issues"
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "debug": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "telegraf": "^2.0.0 || ^3.0.0"
+    "telegraf": "^3.38.0"
   },
   "devDependencies": {
     "coveralls": "^3.1.0",
@@ -67,7 +67,7 @@
     "np": "*",
     "nyc": "^15.1.0",
     "should": "^13.2.3",
-    "telegraf": "^2.0.0 || ^3.0.0"
+    "telegraf": "^3.38.0"
   },
   "np": {
     "yarn": false


### PR DESCRIPTION
Sorry for not realizing this on #59

The JS Code is the same, just the typings are different.

As this changes the required version of telegraf this might be considered a breaking change?