### PR TITLE
fix(typings): fix export

### DIFF
--- a/lib/session.d.ts
+++ b/lib/session.d.ts
@@ -29,5 +29,5 @@ declare module 'telegraf-session-local' {
     static get storageBase(): BaseAdapter
   }
 
-  export default LocalSession
+  export = LocalSession
 }


### PR DESCRIPTION
When the typescript compiler option `esModuleInterop` is enabled the current approach also works which is probably why this slipped through in #59.

fixes #63

After this fix usage for TypeScript (without `esModuleInterop`) is:
```ts
import * as LocalSession from 'telegraf-session-local'
```

With `esModuleInterop` enabled you can use it like this (which is why `esModuleInterop` exists as it wants to simplify importing JavaScript modules exported via `module.export`):
```ts
import LocalSession from 'telegraf-session-local'
```