### PR TITLE
refactor: adapt for telegraf v4.0 and v3.38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - node_modules
 
 node_js:
-  - 10
   - 12
   - 14
+  - 15
 after_success: npm run coverage

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ npm install telegraf-session-local -S
 
 ```js
 const {Telegraf} = require('telegraf')
-const LocalSession = require('../lib/session') // require('telegraf-session-local')
+const LocalSession = require('telegraf-session-local')
 
 const bot = new Telegraf(process.env.BOT_TOKEN) // Your Bot token here
 
@@ -61,7 +61,7 @@ bot.launch()
 
 ```js
 const {Telegraf} = require('telegraf')
-const LocalSession = require('../lib/session') // require('telegraf-session-local')
+const LocalSession = require('telegraf-session-local')
 
 const bot = new Telegraf(process.env.BOT_TOKEN) // Your Bot token here
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ $ npm install telegraf-session-local -S
 ## 👀 Quick-start example
 
 ```js
-const
-  Telegraf = require('telegraf'),
-  LocalSession = require('telegraf-session-local')
+const {Telegraf} = require('telegraf')
+const LocalSession = require('../lib/session') // require('telegraf-session-local')
 
 const bot = new Telegraf(process.env.BOT_TOKEN) // Your Bot token here
 
@@ -55,15 +54,14 @@ bot.command('/remove', (ctx) => {
   ctx.session = null
 })
 
-bot.startPolling()
+bot.launch()
 ```
 
 ## 💡 Full example
 
 ```js
-const
-  Telegraf = require('telegraf'),
-  LocalSession = require('telegraf-session-local')
+const {Telegraf} = require('telegraf')
+const LocalSession = require('../lib/session') // require('telegraf-session-local')
 
 const bot = new Telegraf(process.env.BOT_TOKEN) // Your Bot token here
 
@@ -119,12 +117,12 @@ bot.command('/remove', (ctx) => {
   ctx[property] = null
 })
 
-bot.startPolling()
+bot.launch()
 ```
 
 #### Another examples located in `/examples` folder (PRs welcome)
 Also, you may read comments in  [/lib/session.js](https://github.com/RealSpeaker/telegraf-session-local/blob/master/lib/session.js)
 
-#  
+#
 
 Tema Smirnov and contributors / <github.tema@smirnov.one> / [![Telegram](https://img.shields.io/badge/%F0%9F%92%AC%20Telegram-%40TemaSM-blue.svg)](https://goo.gl/YeV4gk)

--- a/examples/extra.js
+++ b/examples/extra.js
@@ -1,6 +1,5 @@
-const
-  Telegraf = require('telegraf'),
-  LocalSession = require('../lib/session') // require('telegraf-session-local')
+const {Telegraf} = require('telegraf')
+const LocalSession = require('../lib/session') // require('telegraf-session-local')
 
 const bot = new Telegraf(process.env.BOT_TOKEN) // Your Bot token here
 
@@ -56,4 +55,4 @@ bot.command('/remove', (ctx) => {
   ctx[property] = null
 })
 
-bot.startPolling()
+bot.launch()

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,6 +1,5 @@
-const
-  Telegraf = require('telegraf'),
-  LocalSession = require('../lib/session') // require('telegraf-session-local')
+const {Telegraf} = require('telegraf')
+const LocalSession = require('../lib/session') // require('telegraf-session-local')
 
 const bot = new Telegraf(process.env.BOT_TOKEN) // Your Bot token here
 
@@ -23,4 +22,4 @@ bot.command('/remove', (ctx) => {
   ctx.session = null
 })
 
-bot.startPolling()
+bot.launch()

--- a/lib/session.d.ts
+++ b/lib/session.d.ts
@@ -1,7 +1,6 @@
 declare module 'telegraf-session-local' {
   import { AdapterSync, AdapterAsync, BaseAdapter } from 'lowdb'
-  import { Context } from 'telegraf'
-  import { MiddlewareFn } from 'telegraf/typings/composer'
+  import { Context, Middleware } from 'telegraf'
 
   export interface LocalSessionOptions<TSession> {
     storage?: AdapterSync | AdapterAsync
@@ -23,7 +22,7 @@ declare module 'telegraf-session-local' {
     getSessionKey(ctx: Context): string
     getSession(key: string): TSession
     saveSession(key: string, data: TSession): Promise<TSession>
-    middleware(property?: string): MiddlewareFn<Context>
+    middleware(property?: string): Middleware<Context>
     static get storageFileSync(): AdapterSync
     static get storageFileAsync(): AdapterAsync
     static get storageMemory(): AdapterSync

--- a/lib/session.d.ts
+++ b/lib/session.d.ts
@@ -1,6 +1,8 @@
 declare module 'telegraf-session-local' {
   import { AdapterSync, AdapterAsync, BaseAdapter } from 'lowdb'
-  import { Context, Middleware } from 'telegraf'
+  import { Context } from 'telegraf'
+
+  type MiddlewareFn<C extends Context> = (ctx: C, next: () => Promise<void>) => Promise<void>
 
   export interface LocalSessionOptions<TSession> {
     storage?: AdapterSync | AdapterAsync
@@ -22,7 +24,7 @@ declare module 'telegraf-session-local' {
     getSessionKey(ctx: Context): string
     getSession(key: string): TSession
     saveSession(key: string, data: TSession): Promise<TSession>
-    middleware(property?: string): Middleware<Context>
+    middleware(property?: string): MiddlewareFn<Context>
     static get storageFileSync(): AdapterSync
     static get storageFileAsync(): AdapterAsync
     static get storageMemory(): AdapterSync

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "debug": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "telegraf": "^3.0.0 || ^4.0.0"
+    "telegraf": "^3.38.0 || ^4.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "debug": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "telegraf": "^3.38.0"
+    "telegraf": "^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.1.0",
@@ -67,7 +67,7 @@
     "np": "*",
     "nyc": "^15.1.0",
     "should": "^13.2.3",
-    "telegraf": "^3.38.0"
+    "telegraf": "^4.0.1"
   },
   "np": {
     "yarn": false

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "np": "*",
     "nyc": "^15.1.0",
     "should": "^13.2.3",
-    "telegraf": "^4.0.1"
+    "telegraf": "^4.0.2"
   },
   "np": {
     "yarn": false

--- a/tests/general.js
+++ b/tests/general.js
@@ -1,6 +1,6 @@
 /* eslint object-curly-spacing: ["error", "always"] */
 const
-  Telegraf = require('telegraf'),
+  {Telegraf} = require('telegraf'),
   LocalSession = require('../lib/session'),
   should = require('should'),
   debug = require('debug')('telegraf:session-local:test'),
@@ -12,6 +12,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should works without specifying any options for LocalSession', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     const session = new LocalSession()
     bot.on('text', session.middleware(), (ctx) => {
       should.exist(ctx.session)
@@ -25,6 +26,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should use custom `format.serialize` and `format.deserialize` functions', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     const session = new LocalSession({
       database: 'test_sync_db.json',
       storage: LocalSession.storageFileSync,
@@ -49,6 +51,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should have access to lowdb instance via ctx.sessionDB', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('lowdb instance via `ctx.sessionDB` %o', ctx.sessionDB)
       should.exist(ctx.sessionDB)
@@ -59,6 +62,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should override default `session` property to `data` at middleware() call', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware('data'), (ctx) => {
       debug('Overrided session property %o', ctx.data)
       should.exist(ctx.data)
@@ -69,6 +73,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should have access to lowdb instance via overrided property in ctx', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware('data'), (ctx) => {
       debug('lowdb instance via `ctx.dataDB` %o', ctx.dataDB)
       should.exist(ctx.dataDB)
@@ -79,6 +84,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should return `undefined` when context has no `from` field', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Telegraf context `from` field: %o', ctx.from)
       should.not.exists(localSession.getSessionKey(ctx))
@@ -89,6 +95,7 @@ describe('Telegraf Session local : General', () => {
 
   it('Should return `undefined` when no key provided for session to be saved', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), async (ctx) => {
       const sessionKey = localSession.getSessionKey(ctx)
       debug('Real session key calculated by LocalSession: %s', sessionKey)

--- a/tests/sessionKeyUpdateTypes.js
+++ b/tests/sessionKeyUpdateTypes.js
@@ -1,6 +1,6 @@
 /* eslint object-curly-spacing: ["error", "always"] */
 const
-  Telegraf = require('telegraf'),
+  {Telegraf} = require('telegraf'),
   LocalSession = require('../lib/session'),
   should = require('should'),
   debug = require('debug')('telegraf:session-local:test'),
@@ -12,6 +12,7 @@ describe('Telegraf Session local : Session Key Update Types', () => {
 
   it('Should handle message', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', (ctx) => {
       const sessionKey = localSession.getSessionKey(ctx)
       debug('Session key', sessionKey)
@@ -23,6 +24,7 @@ describe('Telegraf Session local : Session Key Update Types', () => {
 
   it('Should handle inline_query', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('inline_query', (ctx) => {
       const sessionKey = localSession.getSessionKey(ctx)
       debug('Session key', sessionKey)
@@ -35,6 +37,7 @@ describe('Telegraf Session local : Session Key Update Types', () => {
 
   it('Should handle callback_query from chat', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.action('c:b', (ctx) => {
       const sessionKey = localSession.getSessionKey(ctx)
       debug('Session key', sessionKey)
@@ -47,6 +50,7 @@ describe('Telegraf Session local : Session Key Update Types', () => {
 
   it('Should handle callback_query from inline_query message', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.action('c:b', (ctx) => {
       const sessionKey = localSession.getSessionKey(ctx)
       debug('Session key', sessionKey)

--- a/tests/storageCustom.js
+++ b/tests/storageCustom.js
@@ -1,6 +1,6 @@
 /* eslint object-curly-spacing: ["error", "always"] */
 const
-  Telegraf = require('telegraf'),
+  {Telegraf} = require('telegraf'),
   LocalSession = require('../lib/session'),
   should = require('should'),
   debug = require('debug')('telegraf:session-local:test')
@@ -38,6 +38,7 @@ describe('Telegraf Session local : storageCustom', () => {
 
   it('storageCustom: Should has session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -50,6 +51,7 @@ describe('Telegraf Session local : storageCustom', () => {
 
   it('storageCustom: Should handle existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -62,6 +64,7 @@ describe('Telegraf Session local : storageCustom', () => {
 
   it('storageCustom: Should handle not existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Not Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -73,6 +76,7 @@ describe('Telegraf Session local : storageCustom', () => {
 
   it('storageCustom: Should handle session reset', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session reset - before %O', ctx.session)
       ctx.session = null

--- a/tests/storageFileAsync.js
+++ b/tests/storageFileAsync.js
@@ -1,6 +1,6 @@
 /* eslint object-curly-spacing: ["error", "always"] */
 const
-  Telegraf = require('telegraf'),
+  {Telegraf} = require('telegraf'),
   LocalSession = require('../lib/session'),
   should = require('should'),
   debug = require('debug')('telegraf:session-local:test'),
@@ -30,6 +30,7 @@ describe('Telegraf Session local : storageFileAsync', () => {
 
   it('storageFileAsync: Should has session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -42,6 +43,7 @@ describe('Telegraf Session local : storageFileAsync', () => {
 
   it('storageFileAsync: Should handle existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -54,6 +56,7 @@ describe('Telegraf Session local : storageFileAsync', () => {
 
   it('storageFileAsync: Should handle not existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Not Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -65,6 +68,7 @@ describe('Telegraf Session local : storageFileAsync', () => {
 
   it('storageFileAsync: Should handle session reset', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session reset - before %O', ctx.session)
       ctx.session = null

--- a/tests/storageFileSync.js
+++ b/tests/storageFileSync.js
@@ -1,6 +1,6 @@
 /* eslint object-curly-spacing: ["error", "always"] */
 const
-  Telegraf = require('telegraf'),
+  {Telegraf} = require('telegraf'),
   LocalSession = require('../lib/session'),
   should = require('should'),
   debug = require('debug')('telegraf:session-local:test'),
@@ -27,6 +27,7 @@ describe('Telegraf Session local : storageFileSync', () => {
 
   it('storageFileSync: Should has session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -39,6 +40,7 @@ describe('Telegraf Session local : storageFileSync', () => {
 
   it('storageFileSync: Should handle existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -51,6 +53,7 @@ describe('Telegraf Session local : storageFileSync', () => {
 
   it('storageFileSync: Should handle not existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Not Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -62,6 +65,7 @@ describe('Telegraf Session local : storageFileSync', () => {
 
   it('storageFileSync: Should handle session reset', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session reset - before %O', ctx.session)
       ctx.session = null

--- a/tests/storageMemory.js
+++ b/tests/storageMemory.js
@@ -1,6 +1,6 @@
 /* eslint object-curly-spacing: ["error", "always"] */
 const
-  Telegraf = require('telegraf'),
+  {Telegraf} = require('telegraf'),
   LocalSession = require('../lib/session'),
   should = require('should'),
   debug = require('debug')('telegraf:session-local:test'),
@@ -26,6 +26,7 @@ describe('Telegraf Session local : storageMemory', () => {
 
   it('storageMemory: Should has session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -38,6 +39,7 @@ describe('Telegraf Session local : storageMemory', () => {
 
   it('storageMemory: Should handle existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -50,6 +52,7 @@ describe('Telegraf Session local : storageMemory', () => {
 
   it('storageMemory: Should handle not existing session', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Not Existing Middleware session %O', ctx.session)
       should.exist(ctx.session)
@@ -61,6 +64,7 @@ describe('Telegraf Session local : storageMemory', () => {
 
   it('storageMemory: Should handle session reset', (done) => {
     bot = new Telegraf()
+    bot.botInfo = {};
     bot.on('text', localSession.middleware(), (ctx) => {
       debug('Middleware session reset - before %O', ctx.session)
       ctx.session = null


### PR DESCRIPTION
The good thing about this: it is not breaking compatibility with 3.38

closes #106

Explanation:

- The example works with both telegraf 3.38 and 4.0 now
  - `const {Telegraf} = require('telegraf')` already works in 3.38
  - `bot.launch()` already works in 3.38 (`bot.startPolling()` was somewhat deprecated)
- the Typescript Types are kind of a hack to not be breaking:
  The import Path of `MiddlewareFn` changed with the update to v4 but `Middleware` is exported from the main export in v3.38 and v4.0. This results in slightly less good typings but as you normally only use `bot.use(sessionLocal)` you wont notice it.

Keep in mind that telegraf v4 requires NodeJS 12. But this is not a requirement of this library on its own so no (breaking) change needed there.